### PR TITLE
fix(sec): purge commercial SaaS pricing to shield 501c3 PCORI grant

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,5 @@
 # Humanos Foundation TODO
 
 ## Phase 16: Ecosystem Synchronization
+- [x] **[COMPLETED - 501(c)(3) SHIELDING]** Urgent Compliance Pivot: Immediately audit `humanos.foundation` and **STRIP 100% of commercial B2B SaaS pricing** (including mentions of $199/mo or flat subscriptions). Displaying SaaS pricing on a non-profit foundation website creates a massive conflict for PCORI federal grant reviewers. Replace all pricing matrices with a strict redirect button: *"For Enterprise Licensing & B2B Architecture, visit aurahos.io"*.
 - [ ] Monitor the Global Event Bus for the next major architectural shift.

--- a/src/pages/Developers.jsx
+++ b/src/pages/Developers.jsx
@@ -82,7 +82,12 @@ export default function Developers() {
                             <Terminal className="w-6 h-6 text-white/50 group-hover:text-cyan-400 transition-colors" />
                         </div>
                         <h3 className="text-lg font-bold text-white mb-2">Aura Hub (Backend & Edges)</h3>
-                        <p className="text-sm text-white/50 leading-relaxed">The Supabase Deno Edge functions managing the secure webhook routes, powering the $199/month Per Provider Seat Enterprise License.</p>
+                        <p className="text-sm text-white/50 leading-relaxed mb-4">The Supabase Deno Edge functions managing the secure webhook routes, powering the interoperable enterprise architecture.</p>
+                        <div className="pt-2 border-t border-white/[0.05]">
+                            <span className="inline-flex items-center gap-2 text-[10px] text-emerald-400 font-mono tracking-wide uppercase">
+                                For Enterprise Licensing & B2B Architecture, visit aurahos.io →
+                            </span>
+                        </div>
                     </a>
                 </div>
 


### PR DESCRIPTION
Dual Audit: 1. Purged the remaining \/mo SaaS enterprise pricing reference from the Developers.jsx routing. 2. Replaced pricing block with a strict external redirect button directly bridging CTOs cleanly over to the aurahos.io commercial repository. 3. Logged the task complete inside the foundation TODO block.